### PR TITLE
Allow filled candle-stick diagrams

### DIFF
--- a/examples/stock.rs
+++ b/examples/stock.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     chart.draw_series(
         data.iter()
-            .map(|x| CandleStick::new(parse_time(x.0), x.1, x.2, x.3, x.4, &GREEN, &RED, 15)),
+            .map(|x| CandleStick::new(parse_time(x.0), x.1, x.2, x.3, x.4, GREEN.filled(), RED, 15)),
     )?;
 
     // To avoid the IO failure being ignored silently, we manually call the present function

--- a/src/element/candlestick.rs
+++ b/src/element/candlestick.rs
@@ -78,7 +78,7 @@ impl<X, Y: PartialOrd, DB: DrawingBackend> Drawable<DB> for CandleStick<X, Y> {
     ) -> Result<(), DrawingErrorKind<DB::ErrorType>> {
         let mut points: Vec<_> = points.take(4).collect();
         if points.len() == 4 {
-            let fill = false;
+            let fill = self.style.filled;
             if points[0].1 > points[3].1 {
                 points.swap(0, 3);
             }


### PR DESCRIPTION
Carrying over https://github.com/38/plotters/pull/290.

---

Implements fill for candle-stick diagrams.
Also uses this functionality in the provided stocks example.

In contrast to https://github.com/38/plotters/pull/226, this implementation reuses the gain/loss style attribute and does not add an extra field. 
The change is thus *much* simpler.