### PR TITLE
Updated Readme to include linux dependencies in font-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ To view the source code for each example, please click on the example image.
 
 ## Table of Contents
   * [Gallery](#gallery)
+  * [Dependecies](#dependencies)
   * [Quick Start](#quick-start)
   * [Trying with Jupyter evcxr Kernel Interactively](#trying-with-jupyter-evcxr-kernel-interactively)
   * [Interactive Tutorial with Jupyter Notebook](#interactive-tutorial-with-jupyter-notebook)
@@ -153,6 +154,14 @@ To view the source code for each example, please click on the example image.
     + [Reducing Depending Libraries && Turning Off Backends](#reducing-depending-libraries--turning-off-backends)
     + [List of Features](#list-of-features)
   * [FAQ List](#faq-list)
+
+
+
+## Dependencies
+
+### Ubuntu Linux
+
+ ```sudo apt install pkg-config libfreetype6-dev libfontconfig1-dev```
 
 ## Quick Start
 
@@ -575,5 +584,4 @@ The following list is a complete list of features that can be opt in and out.
 
 	In the case that error handling is important, you need manually call `present` method before the backend gets dropped.
 	For more information, please see the examples.
-
 


### PR DESCRIPTION
## Overview
- https://crates.io/crates/font-kit has dependencies for ubuntu based linux distros 
- these weren't documented in the readme
- The readme now reflects these requirements for linux users

## Issues
- https://github.com/38/plotters/issues/282
- https://github.com/38/plotters/issues/10
- https://github.com/plotters-rs/guide/issues/1
- https://github.com/38/plotters/pull/319

Quick change, can save a lot of time debugging the inevitable bug that arises from not mentioning it.
